### PR TITLE
Add core Nornir Network Watch functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Nornir Network Watch is a lightweight Python-based network validation tool that 
 - Send real-time alerts to Pushover or other platforms like Slack or Telegram.
 
 Ideal for home labs or production environments that want NetBox-driven monitoring without running a full stack like Prometheus or Zabbix.
+
+## Usage
+
+Install dependencies and run a simple ping check:
+
+```bash
+pip install -r requirements.txt
+NETBOX_URL=https://netbox.example.com NETBOX_TOKEN=1234abcd \
+    python -m nornir_network_watch.cli ping
+```

--- a/nornir_network_watch/__init__.py
+++ b/nornir_network_watch/__init__.py
@@ -1,0 +1,5 @@
+"""Nornir Network Watch package."""
+
+from .core import NornirNetworkWatch, Settings
+
+__all__ = ["NornirNetworkWatch", "Settings"]

--- a/nornir_network_watch/cli.py
+++ b/nornir_network_watch/cli.py
@@ -1,0 +1,32 @@
+"""Command line interface for Nornir Network Watch."""
+from __future__ import annotations
+
+import os
+import argparse
+
+from .core import NornirNetworkWatch, Settings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run simple checks using NetBox data")
+    parser.add_argument("action", choices=["ping"], help="Check to run")
+    parser.add_argument("--url", dest="url", help="NetBox URL", default=os.getenv("NETBOX_URL"))
+    parser.add_argument("--token", dest="token", help="NetBox token", default=os.getenv("NETBOX_TOKEN"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    settings = Settings(netbox_url=args.url, netbox_token=args.token)
+    watcher = NornirNetworkWatch(settings)
+
+    if args.action == "ping":
+        results = watcher.ping()
+        for host, task_result in results.items():
+            print(f"{host}: {task_result[0].result}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/nornir_network_watch/core.py
+++ b/nornir_network_watch/core.py
@@ -1,0 +1,66 @@
+"""Core functionality for Nornir Network Watch.
+
+This module provides a small wrapper around Nornir and the NetBox
+inventory plugin so that network devices can be discovered from NetBox
+and simple validation checks can be executed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import requests
+from nornir import InitNornir
+from nornir.core.plugins.inventory import InventoryPluginRegister
+from nornir_netbox.plugins.inventory.nb_inventory import NetBoxInventory
+from nornir.plugins.tasks import networking
+
+
+@dataclass
+class Settings:
+    """Configuration options for :class:`NornirNetworkWatch`."""
+
+    netbox_url: str
+    netbox_token: str
+
+
+class NornirNetworkWatch:
+    """Lightweight wrapper around Nornir for network validation."""
+
+    def __init__(self, settings: Settings) -> None:
+        InventoryPluginRegister.register("NetBoxInventory", NetBoxInventory)
+        self.nr = InitNornir(
+            inventory={
+                "plugin": "NetBoxInventory",
+                "options": {
+                    "nb_url": settings.netbox_url,
+                    "nb_token": settings.netbox_token,
+                },
+            }
+        )
+
+    def ping(self) -> Dict[str, Any]:
+        """Run ICMP ping against all hosts from NetBox."""
+        return self.nr.run(networking.ping)
+
+    def http(self, url: str, verify: bool = True, timeout: int = 5) -> Dict[str, Any]:
+        """Run a simple HTTP GET request from each host."""
+
+        def _http(task, url: str) -> int:
+            response = requests.get(url, verify=verify, timeout=timeout)
+            return response.status_code
+
+        return self.nr.run(task=_http, url=url)
+
+    def tcp(self, host: str, port: int, timeout: int = 5) -> Dict[str, Any]:
+        """Attempt to open a TCP connection from each host."""
+        import socket
+
+        def _tcp(task, host: str, port: int) -> bool:
+            sock = socket.socket()
+            sock.settimeout(timeout)
+            sock.connect((host, port))
+            sock.close()
+            return True
+
+        return self.nr.run(task=_tcp, host=host, port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+nornir
+nornir-netbox
+requests


### PR DESCRIPTION
## Summary
- Implement core NornirNetworkWatch wrapper with ping, HTTP and TCP checks using NetBox inventory
- Provide CLI to run checks and accept NetBox credentials
- Document usage and dependencies

## Testing
- `python -m py_compile nornir_network_watch/*.py && echo 'py_compile succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_688fcab786988322851a310ada159a6b