### PR TITLE
Add network discovery of unknown devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Run an ARP scan of a network:
 ```bash
 python -m nornir_network_watch.cli arp --network 192.168.1.0/24
 ```
+
+Discover live hosts that are not present in NetBox:
+
+```bash
+NETBOX_URL=https://netbox.example.com NETBOX_TOKEN=1234abcd \
+    python -m nornir_network_watch.cli discover
+```
+
+Sample output:
+
+```
+192.168.1.50: aa:bb:cc:dd:ee:ff
+```

--- a/nornir_network_watch/cli.py
+++ b/nornir_network_watch/cli.py
@@ -9,7 +9,7 @@ from .core import NornirNetworkWatch, Settings
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run simple checks using NetBox data")
-    parser.add_argument("action", choices=["ping", "arp"], help="Check to run")
+    parser.add_argument("action", choices=["ping", "arp", "discover"], help="Check to run")
     parser.add_argument("--url", dest="url", help="NetBox URL", default=os.getenv("NETBOX_URL"))
     parser.add_argument("--token", dest="token", help="NetBox token", default=os.getenv("NETBOX_TOKEN"))
     parser.add_argument(
@@ -35,6 +35,10 @@ def main(argv: list[str] | None = None) -> None:
         if not args.network:
             parser.error("--network is required for arp action")
         results = watcher.arp_scan(args.network)
+        for ip, mac in results.items():
+            print(f"{ip}: {mac}")
+    elif args.action == "discover":
+        results = watcher.discover_unknown_devices()
         for ip, mac in results.items():
             print(f"{ip}: {mac}")
 


### PR DESCRIPTION
## Summary
- discover IP/MAC pairs that are active on the network but missing from NetBox
- expose new `discover` CLI action
- document discovery command with usage examples

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688fdadf319c8322a972350d60e8d903