### PR TITLE
Add HTTPS certificate scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ Sample output:
 192.168.1.50: aa:bb:cc:dd:ee:ff
 ```
 
+Check the remaining validity of an HTTPS certificate:
+
+```bash
+NETBOX_URL=https://netbox.example.com NETBOX_TOKEN=1234abcd \
+    python -m nornir_network_watch.cli https-cert --cert-url https://example.com
+```
+
+Sample output:
+
+```
+localhost: 90 days remaining
+```
+
 ## Tag-based scans
 
 Devices in NetBox can be tagged to control which checks run against them.
@@ -50,6 +63,7 @@ include:
 - `scan:ping` – run ICMP ping checks
 - `scan:http` – perform HTTP GET requests
 - `scan:tcp` – attempt TCP connections
+- `scan:https-cert` – check HTTPS certificate expiry
 
 Use the `--respect-tags` flag with the CLI to limit execution to devices that
 carry the corresponding tag:

--- a/nornir_network_watch/cli.py
+++ b/nornir_network_watch/cli.py
@@ -9,13 +9,22 @@ from .core import NornirNetworkWatch, Settings
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run simple checks using NetBox data")
-    parser.add_argument("action", choices=["ping", "arp", "discover"], help="Check to run")
+    parser.add_argument(
+        "action",
+        choices=["ping", "arp", "discover", "https-cert"],
+        help="Check to run",
+    )
     parser.add_argument("--url", dest="url", help="NetBox URL", default=os.getenv("NETBOX_URL"))
     parser.add_argument("--token", dest="token", help="NetBox token", default=os.getenv("NETBOX_TOKEN"))
     parser.add_argument(
         "--network",
         dest="network",
         help="Network to ARP scan (e.g., 192.168.1.0/24)",
+    )
+    parser.add_argument(
+        "--cert-url",
+        dest="cert_url",
+        help="URL to check for HTTPS certificate expiry",
     )
     parser.add_argument(
         "--respect-tags",
@@ -47,6 +56,13 @@ def main(argv: list[str] | None = None) -> None:
         results = watcher.discover_unknown_devices()
         for ip, mac in results.items():
             print(f"{ip}: {mac}")
+    elif args.action == "https-cert":
+        if not args.cert_url:
+            parser.error("--cert-url is required for https-cert action")
+        results = watcher.check_https_cert(args.cert_url, respect_tags=args.respect_tags)
+        for host, task_result in results.items():
+            days = task_result[0].result
+            print(f"{host}: {days} days remaining")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/nornir_network_watch/core.py
+++ b/nornir_network_watch/core.py
@@ -21,6 +21,7 @@ SCAN_TAG_MAP = {
     "scan:ping": "ping",
     "scan:http": "http",
     "scan:tcp": "tcp",
+    "scan:https-cert": "check_https_cert",
 }
 
 
@@ -128,6 +129,42 @@ class NornirNetworkWatch:
         tag = self._tag_for("tcp")
         nr = self._filter_by_tag(tag) if respect_tags else self.nr
         return nr.run(task=_tcp, host=host, port=port)
+
+    def check_https_cert(
+        self,
+        url: str,
+        timeout: int = 5,
+        respect_tags: bool = False,
+    ) -> Dict[str, Any]:
+        """Check HTTPS certificate expiry for a URL.
+
+        Returns the number of days remaining until the certificate expires.
+
+        If ``respect_tags`` is ``True``, only devices tagged with
+        ``scan:https-cert`` will execute this check.
+        """
+
+        import ssl
+        import socket
+        from datetime import datetime
+        from urllib.parse import urlparse
+
+        def _https_cert(task, url: str) -> int:
+            parsed = urlparse(url)
+            host = parsed.hostname
+            port = parsed.port or 443
+
+            context = ssl.create_default_context()
+            with socket.create_connection((host, port), timeout=timeout) as sock:
+                with context.wrap_socket(sock, server_hostname=host) as ssock:
+                    cert = ssock.getpeercert()
+            not_after = cert["notAfter"]
+            expires = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+            return (expires - datetime.utcnow()).days
+
+        tag = self._tag_for("check_https_cert")
+        nr = self._filter_by_tag(tag) if respect_tags else self.nr
+        return nr.run(task=_https_cert, url=url)
 
     def arp_scan(self, network: str) -> Dict[str, str]:
         """Perform an ARP scan and return a mapping of IP to MAC addresses."""


### PR DESCRIPTION
## Summary
- add HTTPS certificate expiry check with tag `scan:https-cert`
- expose new `https-cert` CLI action with `--cert-url`
- document certificate scanning example

## Testing
- `python -m nornir_network_watch.cli --help` *(fails: ModuleNotFoundError: No module named 'nornir.core.plugins')*

------
https://chatgpt.com/codex/tasks/task_e_688fde59bdf08322978fca5a04e19e46