### PR TITLE
Add optional alerting via Pushover and Slack

### DIFF
--- a/nornir_network_watch/alerts.py
+++ b/nornir_network_watch/alerts.py
@@ -1,0 +1,30 @@
+"""Alerting helpers for Nornir Network Watch."""
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+
+
+def send_pushover(message: str, token: str, user: str) -> None:
+    """Send ``message`` via Pushover."""
+    payload = {"token": token, "user": user, "message": message}
+    requests.post("https://api.pushover.net/1/messages.json", data=payload, timeout=5)
+
+
+def send_slack(message: str, webhook_url: str) -> None:
+    """Send ``message`` to a Slack webhook."""
+    requests.post(webhook_url, json={"text": message}, timeout=5)
+
+
+def send_alert(
+    message: str,
+    pushover_token: Optional[str] = None,
+    pushover_user: Optional[str] = None,
+    slack_webhook: Optional[str] = None,
+) -> None:
+    """Send an alert to any configured backends."""
+    if pushover_token and pushover_user:
+        send_pushover(message, pushover_token, pushover_user)
+    if slack_webhook:
+        send_slack(message, slack_webhook)

--- a/nornir_network_watch/cli.py
+++ b/nornir_network_watch/cli.py
@@ -5,6 +5,7 @@ import os
 import argparse
 
 from .core import NornirNetworkWatch, Settings
+from .alerts import send_alert
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,6 +33,31 @@ def build_parser() -> argparse.ArgumentParser:
         "--tcp-port", dest="tcp_port", type=int, help="Port for TCP check"
     )
     parser.add_argument(
+        "--pushover-token",
+        dest="pushover_token",
+        help="Pushover API token",
+        default=os.getenv("PUSHOVER_TOKEN"),
+    )
+    parser.add_argument(
+        "--pushover-user",
+        dest="pushover_user",
+        help="Pushover user or group key",
+        default=os.getenv("PUSHOVER_USER"),
+    )
+    parser.add_argument(
+        "--slack-webhook",
+        dest="slack_webhook",
+        help="Slack webhook URL",
+        default=os.getenv("SLACK_WEBHOOK"),
+    )
+    parser.add_argument(
+        "--cert-warn-days",
+        dest="cert_warn_days",
+        type=int,
+        help="Days before cert expiry to alert",
+        default=int(os.getenv("CERT_WARNING_DAYS", 30)),
+    )
+    parser.add_argument(
         "--respect-tags",
         action="store_true",
         dest="respect_tags",
@@ -44,13 +70,27 @@ def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    settings = Settings(netbox_url=args.url, netbox_token=args.token)
+    settings = Settings(
+        netbox_url=args.url,
+        netbox_token=args.token,
+        pushover_token=args.pushover_token,
+        pushover_user=args.pushover_user,
+        slack_webhook=args.slack_webhook,
+        cert_warning_days=args.cert_warn_days,
+    )
     watcher = NornirNetworkWatch(settings)
 
     if args.action == "ping":
         results = watcher.ping(respect_tags=args.respect_tags)
         for host, task_result in results.items():
             print(f"{host}: {task_result[0].result}")
+            if task_result.failed:
+                send_alert(
+                    f"Ping failed for {host}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
     elif args.action == "arp":
         if not args.network:
             parser.error("--network is required for arp action")
@@ -68,12 +108,27 @@ def main(argv: list[str] | None = None) -> None:
         for host, task_result in results.items():
             days = task_result[0].result
             print(f"{host}: {days} days remaining")
+            if task_result.failed or days <= settings.cert_warning_days:
+                send_alert(
+                    f"Certificate for {args.cert_url} expires in {days} days ({host})",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
     elif args.action == "http":
         if not args.http_url:
             parser.error("--http-url is required for http action")
         results = watcher.http(args.http_url, respect_tags=args.respect_tags)
         for host, task_result in results.items():
-            print(f"{host}: {task_result[0].result}")
+            status = task_result[0].result
+            print(f"{host}: {status}")
+            if task_result.failed or status >= 400:
+                send_alert(
+                    f"HTTP check failed for {host}: status {status}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
     elif args.action == "tcp":
         if not args.tcp_host or not args.tcp_port:
             parser.error("--tcp-host and --tcp-port are required for tcp action")
@@ -82,6 +137,13 @@ def main(argv: list[str] | None = None) -> None:
         )
         for host, task_result in results.items():
             print(f"{host}: {task_result[0].result}")
+            if task_result.failed:
+                send_alert(
+                    f"TCP check failed for {host}:{args.tcp_port} -> {args.tcp_host}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/nornir_network_watch/core.py
+++ b/nornir_network_watch/core.py
@@ -7,8 +7,9 @@ and simple validation checks can be executed.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
+import os
 import requests
 from nornir import InitNornir
 from nornir.core.plugins.inventory import InventoryPluginRegister
@@ -31,6 +32,10 @@ class Settings:
 
     netbox_url: str
     netbox_token: str
+    pushover_token: Optional[str] = os.getenv("PUSHOVER_TOKEN")
+    pushover_user: Optional[str] = os.getenv("PUSHOVER_USER")
+    slack_webhook: Optional[str] = os.getenv("SLACK_WEBHOOK")
+    cert_warning_days: int = int(os.getenv("CERT_WARNING_DAYS", 30))
 
 
 class NornirNetworkWatch:


### PR DESCRIPTION
## Summary
- add alert helpers for Pushover and Slack
- extend settings and CLI flags to configure alerting
- emit alerts when checks fail or certificates near expiry

## Testing
- `python -m py_compile nornir_network_watch/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe425aabc8322a7c649d889f17783