### PR TITLE
Add YAML configuration support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,34 @@ NETBOX_URL=https://netbox.example.com NETBOX_TOKEN=1234abcd \
 
 Only hosts tagged with `scan:ping` will be included in the run. Without the
 flag all devices from NetBox are scanned.
+
+## Configuration file
+
+Multiple checks can be executed sequentially by defining them in a YAML
+configuration file and passing it to the CLI with ``--config``:
+
+```bash
+python -m nornir_network_watch.cli --config config.yaml
+```
+
+The file contains optional global ``settings`` and a list of ``checks``. Any
+settings not provided fall back to environment variables or CLI arguments. An
+example configuration:
+
+```yaml
+settings:
+  url: https://netbox.example.com
+  token: 1234abcd
+
+checks:
+  - action: ping
+    respect_tags: true
+  - action: https-cert
+    url: https://example.com
+  - action: tcp
+    host: 10.0.0.1
+    port: 22
+```
+
+Each check entry requires an ``action`` and may include any parameters for that
+action such as ``url`` for HTTP/HTTPS checks or ``host``/``port`` for TCP.

--- a/nornir_network_watch/__init__.py
+++ b/nornir_network_watch/__init__.py
@@ -1,5 +1,6 @@
 """Nornir Network Watch package."""
 
 from .core import NornirNetworkWatch, Settings
+from .config import Config, Check, load_config
 
-__all__ = ["NornirNetworkWatch", "Settings"]
+__all__ = ["NornirNetworkWatch", "Settings", "Config", "Check", "load_config"]

--- a/nornir_network_watch/cli.py
+++ b/nornir_network_watch/cli.py
@@ -6,14 +6,21 @@ import argparse
 
 from .core import NornirNetworkWatch, Settings
 from .alerts import send_alert
+from .config import load_config
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run simple checks using NetBox data")
     parser.add_argument(
         "action",
+        nargs="?",
         choices=["ping", "arp", "discover", "https-cert", "http", "tcp"],
         help="Check to run",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        help="Path to YAML configuration file defining checks",
     )
     parser.add_argument("--url", dest="url", help="NetBox URL", default=os.getenv("NETBOX_URL"))
     parser.add_argument("--token", dest="token", help="NetBox token", default=os.getenv("NETBOX_TOKEN"))
@@ -66,9 +73,97 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_check(action: str, watcher: NornirNetworkWatch, settings: Settings, **kwargs) -> None:
+    """Execute a single check ``action`` with ``watcher``.
+
+    Parameters are passed via ``kwargs`` and mirror the CLI options for each
+    action.  Alerts are sent for failed checks using the provided ``settings``.
+    """
+
+    respect_tags = kwargs.get("respect_tags", False)
+    if action == "ping":
+        results = watcher.ping(respect_tags=respect_tags)
+        for host, task_result in results.items():
+            print(f"{host}: {task_result[0].result}")
+            if task_result.failed:
+                send_alert(
+                    f"Ping failed for {host}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
+    elif action == "arp":
+        network = kwargs.get("network")
+        if not network:
+            raise ValueError("network is required for arp action")
+        results = watcher.arp_scan(network)
+        for ip, mac in results.items():
+            print(f"{ip}: {mac}")
+    elif action == "discover":
+        results = watcher.discover_unknown_devices()
+        for ip, mac in results.items():
+            print(f"{ip}: {mac}")
+    elif action == "https-cert":
+        cert_url = kwargs.get("cert_url") or kwargs.get("url")
+        if not cert_url:
+            raise ValueError("cert_url is required for https-cert action")
+        results = watcher.check_https_cert(cert_url, respect_tags=respect_tags)
+        for host, task_result in results.items():
+            days = task_result[0].result
+            print(f"{host}: {days} days remaining")
+            if task_result.failed or days <= settings.cert_warning_days:
+                send_alert(
+                    f"Certificate for {cert_url} expires in {days} days ({host})",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
+    elif action == "http":
+        http_url = kwargs.get("http_url") or kwargs.get("url")
+        if not http_url:
+            raise ValueError("http_url is required for http action")
+        results = watcher.http(http_url, respect_tags=respect_tags)
+        for host, task_result in results.items():
+            status = task_result[0].result
+            print(f"{host}: {status}")
+            if task_result.failed or status >= 400:
+                send_alert(
+                    f"HTTP check failed for {host}: status {status}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
+    elif action == "tcp":
+        host = kwargs.get("tcp_host") or kwargs.get("host")
+        port = kwargs.get("tcp_port") or kwargs.get("port")
+        if not host or not port:
+            raise ValueError("tcp_host and tcp_port are required for tcp action")
+        results = watcher.tcp(host, int(port), respect_tags=respect_tags)
+        for host_name, task_result in results.items():
+            print(f"{host_name}: {task_result[0].result}")
+            if task_result.failed:
+                send_alert(
+                    f"TCP check failed for {host_name}:{port} -> {host}",
+                    settings.pushover_token,
+                    settings.pushover_user,
+                    settings.slack_webhook,
+                )
+    else:  # pragma: no cover - defensive programming
+        raise ValueError(f"Unknown action: {action}")
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.config:
+        cfg = load_config(args.config)
+        watcher = NornirNetworkWatch(cfg.settings)
+        for check in cfg.checks:
+            run_check(check.action, watcher, cfg.settings, **check.options)
+        return
+
+    if not args.action:
+        parser.error("action or --config is required")
 
     settings = Settings(
         netbox_url=args.url,
@@ -80,70 +175,17 @@ def main(argv: list[str] | None = None) -> None:
     )
     watcher = NornirNetworkWatch(settings)
 
-    if args.action == "ping":
-        results = watcher.ping(respect_tags=args.respect_tags)
-        for host, task_result in results.items():
-            print(f"{host}: {task_result[0].result}")
-            if task_result.failed:
-                send_alert(
-                    f"Ping failed for {host}",
-                    settings.pushover_token,
-                    settings.pushover_user,
-                    settings.slack_webhook,
-                )
-    elif args.action == "arp":
-        if not args.network:
-            parser.error("--network is required for arp action")
-        results = watcher.arp_scan(args.network)
-        for ip, mac in results.items():
-            print(f"{ip}: {mac}")
-    elif args.action == "discover":
-        results = watcher.discover_unknown_devices()
-        for ip, mac in results.items():
-            print(f"{ip}: {mac}")
-    elif args.action == "https-cert":
-        if not args.cert_url:
-            parser.error("--cert-url is required for https-cert action")
-        results = watcher.check_https_cert(args.cert_url, respect_tags=args.respect_tags)
-        for host, task_result in results.items():
-            days = task_result[0].result
-            print(f"{host}: {days} days remaining")
-            if task_result.failed or days <= settings.cert_warning_days:
-                send_alert(
-                    f"Certificate for {args.cert_url} expires in {days} days ({host})",
-                    settings.pushover_token,
-                    settings.pushover_user,
-                    settings.slack_webhook,
-                )
-    elif args.action == "http":
-        if not args.http_url:
-            parser.error("--http-url is required for http action")
-        results = watcher.http(args.http_url, respect_tags=args.respect_tags)
-        for host, task_result in results.items():
-            status = task_result[0].result
-            print(f"{host}: {status}")
-            if task_result.failed or status >= 400:
-                send_alert(
-                    f"HTTP check failed for {host}: status {status}",
-                    settings.pushover_token,
-                    settings.pushover_user,
-                    settings.slack_webhook,
-                )
-    elif args.action == "tcp":
-        if not args.tcp_host or not args.tcp_port:
-            parser.error("--tcp-host and --tcp-port are required for tcp action")
-        results = watcher.tcp(
-            args.tcp_host, args.tcp_port, respect_tags=args.respect_tags
-        )
-        for host, task_result in results.items():
-            print(f"{host}: {task_result[0].result}")
-            if task_result.failed:
-                send_alert(
-                    f"TCP check failed for {host}:{args.tcp_port} -> {args.tcp_host}",
-                    settings.pushover_token,
-                    settings.pushover_user,
-                    settings.slack_webhook,
-                )
+    run_check(
+        args.action,
+        watcher,
+        settings,
+        network=args.network,
+        cert_url=args.cert_url,
+        http_url=args.http_url,
+        tcp_host=args.tcp_host,
+        tcp_port=args.tcp_port,
+        respect_tags=args.respect_tags,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/nornir_network_watch/config.py
+++ b/nornir_network_watch/config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Configuration loading for Nornir Network Watch.
+
+This module provides helpers to load YAML configuration files which define
+how :mod:`nornir_network_watch` should run.  A configuration file contains two
+sections:
+
+``settings``
+    Connection details and alerting options.  Any values not supplied will
+    fall back to environment variables in the same way as the CLI options.
+
+``checks``
+    A list of check definitions.  Each entry requires an ``action`` key and
+    may include any options for that action, such as ``url`` for HTTP checks
+    or ``host``/``port`` for TCP checks.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+import os
+
+import yaml
+
+from .core import Settings
+
+
+@dataclass
+class Check:
+    """Single check definition parsed from the configuration file."""
+
+    action: str
+    options: Dict[str, Any]
+
+
+@dataclass
+class Config:
+    """Full configuration consisting of global settings and checks."""
+
+    settings: Settings
+    checks: List[Check]
+
+
+def load_config(path: str) -> Config:
+    """Load configuration from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML file containing configuration data.
+    """
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    settings_data = data.get("settings", {})
+    settings = Settings(
+        netbox_url=settings_data.get("url") or os.getenv("NETBOX_URL"),
+        netbox_token=settings_data.get("token") or os.getenv("NETBOX_TOKEN"),
+        pushover_token=settings_data.get("pushover_token")
+        or os.getenv("PUSHOVER_TOKEN"),
+        pushover_user=settings_data.get("pushover_user")
+        or os.getenv("PUSHOVER_USER"),
+        slack_webhook=settings_data.get("slack_webhook")
+        or os.getenv("SLACK_WEBHOOK"),
+        cert_warning_days=int(
+            settings_data.get("cert_warning_days")
+            or os.getenv("CERT_WARNING_DAYS", 30)
+        ),
+    )
+
+    checks: List[Check] = []
+    for raw_check in data.get("checks", []):
+        action = raw_check.get("action")
+        if not action:
+            raise ValueError("Each check requires an 'action' key")
+        options = {k: v for k, v in raw_check.items() if k != "action"}
+        checks.append(Check(action=action, options=options))
+
+    return Config(settings=settings, checks=checks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nornir
 nornir-netbox
 requests
 scapy
+pyyaml


### PR DESCRIPTION
## Summary
- support running multiple checks from a YAML config file
- accept `--config` in CLI and dispatch checks via helper
- document config file format and add PyYAML requirement

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe6904d308322942389c9a45722de