### PR TITLE
Add warning threshold for HTTPS cert checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ Sample output:
 192.168.1.50: aa:bb:cc:dd:ee:ff
 ```
 
-Check the remaining validity of an HTTPS certificate:
+Check the remaining validity of an HTTPS certificate and warn when it is
+approaching expiry:
 
 ```bash
 NETBOX_URL=https://netbox.example.com NETBOX_TOKEN=1234abcd \
-    python -m nornir_network_watch.cli https-cert --cert-url https://example.com
+    python -m nornir_network_watch.cli https-cert --cert-url https://example.com --warn-days 45
 ```
 
 Sample output:
 
 ```
-localhost: 90 days remaining
+localhost: 10 days remaining (WARNING)
 ```
 
 ## Tag-based scans


### PR DESCRIPTION
## Summary
- support warning threshold for certificate expiry via new `warn_days` option
- allow `--warn-days` flag in CLI to surface warnings and alerts
- document certificate warning usage

## Testing
- `python -m py_compile nornir_network_watch/core.py nornir_network_watch/cli.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe8330ff8832293359c76fdc60768